### PR TITLE
chore: bump otter for runtime app registry

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,7 +5,7 @@ tag = True
 tag_name = v{new_version}
 message = chore(release): v{new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:VERSION]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to the Kymatics stack release will be documented in this file.
 
-## [Unreleased]\n\n## [1.0.1] - 2026-04-01
+## [Unreleased]
+
+### Added
+- Persistent runtime app registry (workspace + job runtime instances) and shutdown-all endpoint for clean runtime shutdown.
 
 ## [1.0.0] - 2026-04-01
 

--- a/SUBMODULE_VERSIONS.md
+++ b/SUBMODULE_VERSIONS.md
@@ -13,4 +13,3 @@ So for releases we do two things:
 - `seal`: `v1.0.0`
 - `otter`: `v1.0.1`
 - `lavoix`: `v1.0.0`
-


### PR DESCRIPTION
## Summary
Bumps the `otter` submodule to include persistent runtime app registry metadata and new runtime endpoints for shutdown/cleanup.

## Includes
- `GET /v1/runtime/app-registry` (running entries)
- `POST /v1/runtime/apps/shutdown-all`
- Runtime start/stop syncs job/workspace registry
