### PR TITLE
chore: bump otter for self-contained project guardrails

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -5,7 +5,7 @@ tag = True
 tag_name = v{new_version}
 message = chore(release): v{new_version}
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)
-serialize = 
+serialize =
 	{major}.{minor}.{patch}
 
 [bumpversion:file:VERSION]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Kymatics stack release will be documented in this fil
 
 ### Added
 - Persistent runtime app registry (workspace + job runtime instances) and shutdown-all endpoint for clean runtime shutdown.
+- Self-contained project guardrails for runtime `working_directory` and job `project_path`; workspace root marker file for safe cleanup defaults.
 
 ## [1.0.0] - 2026-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 All notable changes to the Kymatics stack release will be documented in this file.
 
-## [Unreleased]\n\n## [1.0.1] - 2026-04-01
+## [Unreleased]
+
+### Added
+- Persistent runtime app registry (workspace + job runtime instances) and shutdown-all endpoint for clean runtime shutdown.
 
 ## [1.0.0] - 2026-04-01
 

--- a/SUBMODULE_VERSIONS.md
+++ b/SUBMODULE_VERSIONS.md
@@ -13,4 +13,3 @@ So for releases we do two things:
 - `seal`: `v1.0.0`
 - `otter`: `v1.0.1`
 - `lavoix`: `v1.0.0`
-


### PR DESCRIPTION
## Summary
Bumps the `otter` submodule to include runtime self-contained project guardrails.

## Includes
- Validation for `POST /v1/jobs/{id}/project-path` and `POST /v1/jobs/{id}/runtime-launch`.
- Workspace creation now writes a workspace root marker file.
